### PR TITLE
bugfix - Changed the template, mobile menu and the search list background color to avoid overlaps

### DIFF
--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -18,12 +18,12 @@ const DropdownMenu = () => {
           <DoteMenuIcon />
         </Button>
         {dropdown && (
-          <div className="absolute z-10 w-[250px] right-1 origin-top-right mt-2 rounded-lg bg-glass">
+          <div className="absolute z-10 w-[250px] right-1 origin-top-right mt-2 rounded-lg bg-dark border border-glass">
             <div className="px-1 py-1 shadow-md rounded-lg flex flex-col ">
-              <p className="px-3 mt-2 overflow-hidden whitespace-nowrap">
+              <p className=" text-sm px-3 mt-2 overflow-hidden whitespace-nowrap">
                 About
               </p>
-              <HorizontalLine style="my-1" />
+              <HorizontalLine style="my-2" />
               <Link
                 href="/"
                 className="flex items-center px-3 py-2 my-1 text-sm text-start font-medium rounded-md duration-300"

--- a/src/components/doc/Search.tsx
+++ b/src/components/doc/Search.tsx
@@ -33,7 +33,7 @@ const Search = () => {
         onFocus={handleOpenSearchList}
       />
       {dropdown && (
-        <div className="lg:w-[70%] md:w-[90%] w-full lg:h-[220px] h-[180px] absolute top-16 flex flex-col space-y-2 rounded-lg p-4 bg-glass overflow-auto">
+        <div className="lg:w-[70%] md:w-[90%] w-full lg:h-[220px] h-[180px] absolute top-16 flex flex-col space-y-2 rounded-lg p-4 bg-dark border border-glass overflow-auto">
           {searchedData.map((parentData, parentInd) => {
             return (
               <>

--- a/src/features/templates/Templates.tsx
+++ b/src/features/templates/Templates.tsx
@@ -10,8 +10,8 @@ const Templates = () => {
     return null;
   }
   return (
-    <aside className=" absolute lg:sticky top-[62px] md:top-[71px] right-0 lg:top-0 left-0 bottom-2 lg:bg-transparent lg:mr-3 flex items-start justify-start rounded-lg">
-      <section className="flex flex-col items-start justify-start w-[90%] md:w-[280px] lg:w-[300px] lg:h-[89vh] h-full bg-glass rounded-lg py-5 px-4">
+    <aside className=" absolute lg:sticky z-50 top-[62px] md:top-[71px] right-0 lg:top-0 left-0 bottom-0 lg:bg-transparent bg-glass lg:mr-3 flex items-start justify-start rounded-lg">
+      <section className="flex flex-col items-start justify-start w-[90%] md:w-[280px] lg:w-[300px] lg:h-[89vh] h-full bg-dark border border-glass rounded-lg py-5 px-4">
         <p className="lg:mb-8 mb-6"> Templates</p>
 
         {[1, 2, 3, 4]?.map((data, ind) => {


### PR DESCRIPTION
## #23  Description

Changed the **template**, **mobile menu** and the **search list** background colour to avoid overlaps.

## Before
![image](https://github.com/ashrafchowdury/dotemd/assets/87828904/85e84f54-d405-47f8-92f3-8e2749251208)


## After
![image](https://github.com/ashrafchowdury/dotemd/assets/87828904/59971459-f6b7-4ef1-9405-5f7b74caf201)


