### PR TITLE
feature - added local-storage feature to save editor data locally

### DIFF
--- a/src/features/editor/TextEditor.tsx
+++ b/src/features/editor/TextEditor.tsx
@@ -1,13 +1,21 @@
 "use client";
 
+import { useEffect } from "react";
 import EditorMenu from "./components/EditorMenu";
 import { EditorContent } from "@tiptap/react";
 import { useEditor } from "./context/useEditor";
 import InlineSelector from "./components/InlineSelector";
 import TableSelector from "./components/TableSelector";
+import { useLocalData } from "./hooks/useLocalData";
 
 const TextEditor = () => {
   const { editorRef, editor } = useEditor();
+  const { updateLocalData, getLocalData } = useLocalData();
+
+  useEffect(() => {
+    getLocalData();
+  }, [editor]);
+
   return (
     <section className=" w-full">
       <EditorMenu />
@@ -15,7 +23,12 @@ const TextEditor = () => {
       <TableSelector />
 
       {/***  TipTap RichText Editor ***/}
-      <EditorContent ref={editorRef} editor={editor} className="editor" />
+      <EditorContent
+        ref={editorRef}
+        editor={editor}
+        className="editor"
+        onKeyDown={updateLocalData}
+      />
     </section>
   );
 };

--- a/src/features/editor/hooks/useLocalData.tsx
+++ b/src/features/editor/hooks/useLocalData.tsx
@@ -1,0 +1,37 @@
+import { useRef } from "react";
+import { useEditor } from "../context/useEditor";
+import toaster from "@/components/ui/toaster";
+
+export const useLocalData = () => {
+  const keyCountRef = useRef(0);
+  const { editor } = useEditor();
+
+  const updateLocalData = () => {
+    keyCountRef.current += 1;
+    // Execute as action after every 10 keyboard key presses
+    if (keyCountRef.current % 10 === 0) {
+      localStorage.setItem("editor", editor?.getHTML());
+    }
+  };
+
+  const getLocalData = () => {
+    const getLsData = localStorage.getItem("editor");
+    if (getLsData) {
+      toaster({
+        title: "Restore Previous Data",
+        about: "Restore your previous writing data",
+        type: "alert",
+        btnOne: { title: "Cancel", onclcik: () => null },
+        btnTwo: {
+          title: "Restore",
+          onclcik: () => {
+            editor?.commands.clearContent();
+            editor?.commands.insertContent(getLsData);
+          },
+        },
+      });
+    }
+  };
+
+  return { updateLocalData, getLocalData };
+};


### PR DESCRIPTION
## #33 Description

Added the **support of local storage to save data automatically on local storage**, I have created a function which will update the local data every **10 key presses on the keyboard**. 

When the user enters the editor if local storage has any editor data then it will be going to push a notification to restore the data.